### PR TITLE
Fix licence in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP INI Parser Library",
     "keywords": ["ini", "parser"],
     "homepage": "http://github.com/china-cn-dev/ini-parser",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Li Liang",


### PR DESCRIPTION
```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
License "Apache 2.0" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```